### PR TITLE
Add reliable drivers page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import AlphabetPage from './pages/AlphabetPage'
 import WordsPage from './pages/WordsPage'
 import PhrasesPage from './pages/PhrasesPage'
 import InterestingNotes from './pages/InterestingNotes'
+import ReliableDriversPage from './pages/ReliableDriversPage'
 import { LanguageProvider } from './useLanguage'
 import SideNav from './components/SideNav'
 import './index.css'
@@ -22,6 +23,7 @@ export default function App() {
               <Route path="/alphabet" element={<AlphabetPage />} />
               <Route path="/words" element={<WordsPage />} />
               <Route path="/phrases" element={<PhrasesPage />} />
+              <Route path="/drivers" element={<ReliableDriversPage />} />
               <Route path="/interesting_notes" element={<InterestingNotes />} />
             </Routes>
           </div>

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -9,6 +9,7 @@ export default function SideNav() {
     { to: '/alphabet', label: t('nav_alphabet') },
     { to: '/words', label: t('nav_words') },
     { to: '/phrases', label: t('nav_phrases') },
+    { to: '/drivers', label: t('nav_drivers') },
     { to: '/interesting_notes', label: t('nav_interesting_notes') },
   ]
 

--- a/frontend/src/pages/ReliableDriversPage.tsx
+++ b/frontend/src/pages/ReliableDriversPage.tsx
@@ -1,0 +1,76 @@
+import { useLanguage } from '../useLanguage'
+
+interface Driver {
+  name: string
+  region: { en: string; ru: string }
+  cars: string
+  phones: string[]
+  website?: string
+}
+
+const drivers: Driver[] = [
+  {
+    name: 'Жора',
+    region: { en: 'Gyumri', ru: 'Гюмри' },
+    cars: '-',
+    phones: ['077411503'],
+  },
+  {
+    name: 'Гор',
+    region: { en: 'Tsaghkadzor', ru: 'Цахкадзор' },
+    cars: '-',
+    phones: ['+374 93 584 455'],
+    website: 'https://tour-armenia.am/',
+  },
+  {
+    name: 'Сергей',
+    region: { en: 'Sevan', ru: 'Севан' },
+    cars: '-',
+    phones: ['095244404'],
+  },
+  {
+    name: 'Алек',
+    region: { en: 'Sevan', ru: 'Севан' },
+    cars: '-',
+    phones: ['+37493390681'],
+  },
+]
+
+export default function ReliableDriversPage() {
+  const { lang, t } = useLanguage()
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">{t('drivers_title')}</h1>
+      <table className="table-auto border-collapse w-full">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">{t('drivers_col_name')}</th>
+            <th className="border px-2 py-1">{t('drivers_col_region')}</th>
+            <th className="border px-2 py-1">{t('drivers_col_cars')}</th>
+            <th className="border px-2 py-1">{t('drivers_col_phones')}</th>
+            <th className="border px-2 py-1">{t('drivers_col_site')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {drivers.map((d) => (
+            <tr key={d.name}>
+              <td className="border px-2 py-1">{d.name}</td>
+              <td className="border px-2 py-1">{d.region[lang]}</td>
+              <td className="border px-2 py-1">{d.cars}</td>
+              <td className="border px-2 py-1">{d.phones.join(', ')}</td>
+              <td className="border px-2 py-1">
+                {d.website ? (
+                  <a href={d.website} target="_blank" rel="noopener noreferrer">
+                    {d.website}
+                  </a>
+                ) : (
+                  '-'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/useLanguage.tsx
+++ b/frontend/src/useLanguage.tsx
@@ -14,6 +14,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_alphabet: 'Alphabet trainer',
     nav_words: 'Word trainer',
     nav_phrases: 'Phrase trainer',
+    nav_drivers: 'Reliable drivers',
     nav_interesting_notes: 'Interesting notes',
     alphabet_title: 'Armenian Alphabet',
     words_title: 'Simple Words',
@@ -51,7 +52,13 @@ const strings: Record<Lang, Record<string, string>> = {
     note_2025_06_19_p2:
       'Once while walking through Arabkir near Druzhba station, we stopped by a pharmacy and, to our surprise, saw an owl in the middle of the room. Motionless, it mechanically turned its head at regular intervals. We thought nothing of it and went home.',
     note_2025_06_19_p3:
-      'A year later we learned the owl was alive. The pharmacy owner, Artur, had rescued her after a car accident. She lost a wing and now lives in the pharmacy. Her name is Lurik, and she is a small landmark of Komitas Street. The shop itself feels like a magic box with hidden doors\u2014but that is another story.'
+      'A year later we learned the owl was alive. The pharmacy owner, Artur, had rescued her after a car accident. She lost a wing and now lives in the pharmacy. Her name is Lurik, and she is a small landmark of Komitas Street. The shop itself feels like a magic box with hidden doors\u2014but that is another story.',
+    drivers_title: 'Reliable drivers',
+    drivers_col_name: 'Driver',
+    drivers_col_region: 'Region',
+    drivers_col_cars: 'Available cars',
+    drivers_col_phones: 'Phones',
+    drivers_col_site: 'Website',
   },
   ru: {
     welcome_title: 'Добро пожаловать в тренажеры армянского языка',
@@ -59,6 +66,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_alphabet: 'Тренажер алфавита',
     nav_words: 'Тренажер слов',
     nav_phrases: 'Тренажер фраз',
+    nav_drivers: 'Проверенные водители',
     nav_interesting_notes: 'любопытные заметки',
     alphabet_title: 'Армянский алфавит',
     words_title: 'Простые слова',
@@ -96,7 +104,13 @@ const strings: Record<Lang, Record<string, string>> = {
     note_2025_06_19_p2:
       'Однажды, гуляя по району Арабкир недалеко от метро Дружба, мы зашли в аптеку и увидели посередине помещения сову — или чучело совы. Она сидела неподвижно и механически поворачивала голову. Мы пожали плечами и ушли.',
     note_2025_06_19_p3:
-      'Через год мы узнали, что сова всё-таки живая. Машина сбила её, и хозяин аптеки Артур выходил её, хотя она потеряла крыло. Теперь Лурик — так зовут совушку — живёт в аптеке и стала достопримечательностью улицы Комитаса. Сама аптека похожа на волшебную шкатулку с тайными дверцами, но это уже другая история.'
+      'Через год мы узнали, что сова всё-таки живая. Машина сбила её, и хозяин аптеки Артур выходил её, хотя она потеряла крыло. Теперь Лурик — так зовут совушку — живёт в аптеке и стала достопримечательностью улицы Комитаса. Сама аптека похожа на волшебную шкатулку с тайными дверцами, но это уже другая история.',
+    drivers_title: 'Проверенные водители',
+    drivers_col_name: 'Водитель',
+    drivers_col_region: 'Регион',
+    drivers_col_cars: 'Доступные машины',
+    drivers_col_phones: 'Телефоны',
+    drivers_col_site: 'Сайт',
   },
 }
 


### PR DESCRIPTION
## Summary
- add bilingual Reliable Drivers page and translations
- expose Reliable Drivers route and navigation entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f5b89409c8321be56aedec7585a42