### PR TITLE
docs: add frontend deployment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ npm install
 npm run dev
 ```
 
+To deploy the HTML frontend to Firebase Hosting:
+```bash
+npm --prefix frontend run build && firebase deploy --only hosting
+```
+
 ## Backend
 - Python 3.11 Flask API
 - `/tts` endpoint uses Google Cloud Text-to-Speech


### PR DESCRIPTION
## Summary
- document how to build and deploy the HTML frontend to Firebase Hosting

## Testing
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f6329f70883218e2e4ffbba267000