### PR TITLE
feat: add localized routes with SEO tags

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "firebase": "^11.9.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-helmet": "^6.1.0",
         "react-router-dom": "^6.30.1",
         "tailwindcss": "^4.1.10"
       },
@@ -3655,7 +3656,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4005,6 +4005,18 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4141,6 +4153,15 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4293,6 +4314,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
@@ -4368,6 +4400,42 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-helmet/node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1",
+    "react-helmet": "^6.1.0",
     "tailwindcss": "^4.1.10"
   },
   "devDependencies": {

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,18 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://am-lang.web.app/</loc>
+    <loc>https://am-lang.web.app/en</loc>
   </url>
   <url>
-    <loc>https://am-lang.web.app/alphabet</loc>
+    <loc>https://am-lang.web.app/ru</loc>
   </url>
   <url>
-    <loc>https://am-lang.web.app/words</loc>
+    <loc>https://am-lang.web.app/en/alphabet</loc>
   </url>
   <url>
-    <loc>https://am-lang.web.app/phrases</loc>
+    <loc>https://am-lang.web.app/ru/alphabet</loc>
   </url>
   <url>
-    <loc>https://am-lang.web.app/interesting_notes</loc>
+    <loc>https://am-lang.web.app/en/words</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/words</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/en/phrases</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/phrases</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/en/drivers</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/drivers</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/en/interesting_notes</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/interesting_notes</loc>
   </url>
 </urlset>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import usePageViews from './usePageViews'
 import WelcomePage from './pages/WelcomePage'
 import AlphabetPage from './pages/AlphabetPage'
@@ -12,24 +12,26 @@ import './index.css'
 
 export default function App() {
   return (
-    <LanguageProvider>
-      <BrowserRouter>
+    <BrowserRouter>
+      <LanguageProvider>
         <TrackPageViews />
         <div className="flex min-h-screen">
           <SideNav />
           <div className="flex-1 ml-64">
             <Routes>
-              <Route path="/" element={<WelcomePage />} />
-              <Route path="/alphabet" element={<AlphabetPage />} />
-              <Route path="/words" element={<WordsPage />} />
-              <Route path="/phrases" element={<PhrasesPage />} />
-              <Route path="/drivers" element={<ReliableDriversPage />} />
-              <Route path="/interesting_notes" element={<InterestingNotes />} />
+              <Route path="/" element={<Navigate to="/en" replace />} />
+              <Route path="/:lang" element={<WelcomePage />} />
+              <Route path="/:lang/alphabet" element={<AlphabetPage />} />
+              <Route path="/:lang/words" element={<WordsPage />} />
+              <Route path="/:lang/phrases" element={<PhrasesPage />} />
+              <Route path="/:lang/drivers" element={<ReliableDriversPage />} />
+              <Route path="/:lang/interesting_notes" element={<InterestingNotes />} />
+              <Route path="*" element={<Navigate to="/en" replace />} />
             </Routes>
           </div>
         </div>
-      </BrowserRouter>
-    </LanguageProvider>
+      </LanguageProvider>
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/components/Meta.tsx
+++ b/frontend/src/components/Meta.tsx
@@ -1,0 +1,19 @@
+import { Helmet } from 'react-helmet'
+import { useLocation } from 'react-router-dom'
+import { useLanguage } from '../useLanguage'
+
+export default function Meta() {
+  const { lang } = useLanguage()
+  const location = useLocation()
+  const path = location.pathname.replace(/^\/(en|ru)/, '') || '/'
+  const canonical = `https://am-lang.web.app/${lang}${path}`
+  const en = `https://am-lang.web.app/en${path}`
+  const ru = `https://am-lang.web.app/ru${path}`
+  return (
+    <Helmet>
+      <link rel="canonical" href={canonical} />
+      <link rel="alternate" href={en} hrefLang="en" />
+      <link rel="alternate" href={ru} hrefLang="ru" />
+    </Helmet>
+  )
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -6,13 +6,13 @@ export default function NavBar() {
   return (
     <header className="p-4 flex gap-4 items-center bg-gray-100">
       <nav className="flex gap-4 flex-1">
-        <Link to="/" className="font-semibold">
+        <Link to={`/${lang}`} className="font-semibold">
           {t('welcome_title')}
         </Link>
-        <Link to="/alphabet">{t('nav_alphabet')}</Link>
-        <Link to="/words">{t('nav_words')}</Link>
-        <Link to="/phrases">{t('nav_phrases')}</Link>
-        <Link to="/interesting_notes">{t('nav_interesting_notes')}</Link>
+        <Link to={`/${lang}/alphabet`}>{t('nav_alphabet')}</Link>
+        <Link to={`/${lang}/words`}>{t('nav_words')}</Link>
+        <Link to={`/${lang}/phrases`}>{t('nav_phrases')}</Link>
+        <Link to={`/${lang}/interesting_notes`}>{t('nav_interesting_notes')}</Link>
       </nav>
       <select
         className="border px-2 py-1"

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -5,18 +5,19 @@ export default function SideNav() {
   const { lang, setLang, t } = useLanguage()
   const location = useLocation()
 
+  const base = `/${lang}`
   const items = [
-    { to: '/alphabet', label: t('nav_alphabet') },
-    { to: '/words', label: t('nav_words') },
-    { to: '/phrases', label: t('nav_phrases') },
-    { to: '/drivers', label: t('nav_drivers') },
-    { to: '/interesting_notes', label: t('nav_interesting_notes') },
+    { to: `${base}/alphabet`, label: t('nav_alphabet') },
+    { to: `${base}/words`, label: t('nav_words') },
+    { to: `${base}/phrases`, label: t('nav_phrases') },
+    { to: `${base}/drivers`, label: t('nav_drivers') },
+    { to: `${base}/interesting_notes`, label: t('nav_interesting_notes') },
   ]
 
   return (
     <nav className="fixed w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between">
       <div>
-        <Link to="/" className="block uppercase font-bold mb-4">
+        <Link to={base} className="block uppercase font-bold mb-4">
           {t('welcome_title')}
         </Link>
         <select
@@ -44,7 +45,7 @@ export default function SideNav() {
         </ul>
       </div>
       <Link
-        to="/alphabet"
+        to={`${base}/alphabet`}
         className="mt-6 block text-center bg-white text-blue-800 font-bold border border-blue-800 rounded py-3 hover:bg-blue-50"
       >
         Start Learning

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 import polarOwl from '../assets/polar_owl.webp'
 import appleImg from '../assets/alphabet/apple.webp'
 import apricotImg from '../assets/alphabet/apricot.webp'
@@ -532,7 +533,9 @@ export default function AlphabetPage() {
   }
 
   return (
-    <div className="p-4">
+    <>
+      <Meta />
+      <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('alphabet_title')}</h1>
       <table className="table-auto border-collapse">
         <thead>
@@ -557,7 +560,7 @@ export default function AlphabetPage() {
               <td className="border px-2 text-center text-2xl">{armLower}</td>
               <td className="border px-2">{en}</td>
               <td className="border px-2">{ru}</td>
-            </tr>
+          </tr>
             )
           })}
         </tbody>
@@ -566,5 +569,6 @@ export default function AlphabetPage() {
         <LetterModal info={active} onClose={() => setActive(null)} />
       )}
     </div>
+    </>
   )
 }

--- a/frontend/src/pages/InterestingNotes.tsx
+++ b/frontend/src/pages/InterestingNotes.tsx
@@ -1,4 +1,5 @@
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 import architectImg from '../assets/architect.webp'
 import lurikImg from '../assets/stories/lurik_00.png'
 import type { ReactNode } from 'react'
@@ -51,7 +52,9 @@ const notes: Note[] = [
 export default function InterestingNotes() {
   const { t } = useLanguage()
   return (
-    <div className="p-4">
+    <>
+      <Meta />
+      <div className="p-4">
       <h1 className="text-xl font-bold mb-4">
         {t('interesting_notes_title')}
       </h1>
@@ -67,5 +70,6 @@ export default function InterestingNotes() {
         ))}
       </ul>
     </div>
+    </>
   )
 }

--- a/frontend/src/pages/PhrasesPage.tsx
+++ b/frontend/src/pages/PhrasesPage.tsx
@@ -21,6 +21,7 @@ import notArmenianImg from '../assets/phrases/i_am_not_armenian.webp'
 import whatIsThatImg from '../assets/phrases/what_is_that.webp'
 import myNameIsImg from '../assets/phrases/my_name_is.webp'
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 
 interface Phrase {
   image?: string
@@ -192,7 +193,9 @@ export default function PhrasesPage() {
   const current = phrases[index]
 
   return (
-    <div className="p-4">
+    <>
+      <Meta />
+      <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('phrases_title')}</h1>
       <div className="mb-4">
         <select
@@ -258,5 +261,6 @@ export default function PhrasesPage() {
         </div>
       )}
     </div>
+    </>
   )
 }

--- a/frontend/src/pages/ReliableDriversPage.tsx
+++ b/frontend/src/pages/ReliableDriversPage.tsx
@@ -1,4 +1,5 @@
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 
 interface Driver {
   name: string
@@ -39,7 +40,9 @@ const drivers: Driver[] = [
 export default function ReliableDriversPage() {
   const { lang, t } = useLanguage()
   return (
-    <div className="p-4">
+    <>
+      <Meta />
+      <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('drivers_title')}</h1>
       <table className="table-auto border-collapse w-full">
         <thead>
@@ -72,5 +75,6 @@ export default function ReliableDriversPage() {
         </tbody>
       </table>
     </div>
+    </>
   )
 }

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -2,17 +2,20 @@ import araratImg from '../assets/ararat.webp'
 import boarImg from '../assets/little-boar400x600.webp'
 import telegramLogo from '../assets/telegram_logo.svg'
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 
 export default function WelcomePage() {
   const { t } = useLanguage()
   return (
-    <div className="relative flex flex-col items-center gap-4 p-4">
-      <img src={araratImg} alt="Mount Ararat" className="w-320 rounded" />
-      <div className="fixed right-4 bottom-4 w-40">      
-        <img
-          src={boarImg}
-          alt="Little boar"        
-        />
+    <>
+      <Meta />
+      <div className="relative flex flex-col items-center gap-4 p-4">
+        <img src={araratImg} alt="Mount Ararat" className="w-320 rounded" />
+        <div className="fixed right-4 bottom-4 w-40">
+          <img
+            src={boarImg}
+            alt="Little boar"
+          />
         <p style={{position: "relative", top:-30}}>
           <a href="https://t.me/alina_yerevan_js"
               target="_blank" rel="noopener">
@@ -23,6 +26,7 @@ export default function WelcomePage() {
       </div>
       <h1 className="text-4xl font-bold">{t('welcome_title')}</h1>
       <p className="text-2xl text-left max-w-prose">{t('welcome_desc')}</p>
-    </div>
+      </div>
+    </>
   )
 }

--- a/frontend/src/pages/WordsPage.tsx
+++ b/frontend/src/pages/WordsPage.tsx
@@ -1,4 +1,5 @@
 import { useLanguage } from '../useLanguage'
+import Meta from '../components/Meta'
 import appleImg from '../assets/alphabet/apple.webp'
 import apricotImg from '../assets/alphabet/apricot.webp'
 import bookImg from '../assets/alphabet/book.webp'
@@ -101,7 +102,9 @@ const words: Word[] = [
 export default function WordsPage() {
   const { t } = useLanguage()
   return (
-    <div className="p-4">
+    <>
+      <Meta />
+      <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('words_title')}</h1>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {words.map((w) => (
@@ -129,5 +132,6 @@ export default function WordsPage() {
         ))}
       </div>
     </div>
+    </>
   )
 }

--- a/frontend/src/useLanguage.tsx
+++ b/frontend/src/useLanguage.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 type Lang = 'en' | 'ru'
 interface I18n {
@@ -117,7 +118,28 @@ const strings: Record<Lang, Record<string, string>> = {
 const LanguageContext = createContext<I18n | undefined>(undefined)
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [lang, setLang] = useState<Lang>('en')
+  const location = useLocation()
+  const navigate = useNavigate()
+  const initial = (location.pathname.match(/^\/(en|ru)/)?.[1] as Lang) || 'en'
+  const [lang, setLangState] = useState<Lang>(initial)
+
+  useEffect(() => {
+    const current = location.pathname.match(/^\/(en|ru)/)?.[1] as Lang | undefined
+    if (current && current !== lang) {
+      setLangState(current)
+    }
+  }, [location.pathname, lang])
+
+  useEffect(() => {
+    document.documentElement.lang = lang
+  }, [lang])
+
+  const setLang = (l: Lang) => {
+    const rest = location.pathname.replace(/^\/(en|ru)/, '')
+    navigate(`/${l}${rest}${location.search}${location.hash}`)
+    setLangState(l)
+  }
+
   const t = (key: string) => strings[lang][key] || key
   return (
     <LanguageContext.Provider value={{ lang, setLang, t }}>


### PR DESCRIPTION
## Summary
- route app under language prefixes like `/en/phrases` and sync language state with URL
- inject canonical and `hreflang` tags for each page using `react-helmet`
- list both English and Russian paths in `sitemap.xml`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f73e40fa883219378380977446ad3