### PR TITLE
Add slideable side navigation for mobile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { useState } from 'react'
 import usePageViews from './usePageViews'
 import WelcomePage from './pages/WelcomePage'
 import AlphabetPage from './pages/AlphabetPage'
@@ -11,13 +12,15 @@ import SideNav from './components/SideNav'
 import './index.css'
 
 export default function App() {
+  const [navOpen, setNavOpen] = useState(true)
   return (
     <BrowserRouter>
       <LanguageProvider>
         <TrackPageViews />
         <div className="flex min-h-screen">
-          <SideNav />
-          <div className="flex-1 ml-64">
+          {/** Side navigation with slide toggle **/}
+          <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} />
+          <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-64' : 'ml-0'}`}>
             <Routes>
               <Route path="/" element={<Navigate to="/en" replace />} />
               <Route path="/:lang" element={<WelcomePage />} />

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -1,7 +1,12 @@
 import { Link, useLocation } from 'react-router-dom'
 import { useLanguage } from '../useLanguage'
 
-export default function SideNav() {
+interface SideNavProps {
+  open: boolean
+  toggle: () => void
+}
+
+export default function SideNav({ open, toggle }: SideNavProps) {
   const { lang, setLang, t } = useLanguage()
   const location = useLocation()
 
@@ -15,44 +20,65 @@ export default function SideNav() {
   ]
 
   return (
-    <nav className="fixed w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between">
-      <div>
-        <Link to={base} className="block uppercase font-bold mb-4">
-          {t('welcome_title')}
-        </Link>
-        <select
-          className="mb-6 bg-sky-100 border rounded px-2 py-1 text-sm w-full"
-          value={lang}
-          onChange={(e) => setLang(e.target.value as 'en' | 'ru')}
-        >
-          <option value="en">EN</option>
-          <option value="ru">RU</option>
-        </select>
-        <ul className="space-y-2">
-          {items.map(({ to, label }) => {
-            const active = location.pathname === to
-            return (
-              <li key={to}>
-                <Link
-                  to={to}
-                  className={`block px-3 py-2 rounded uppercase ${active ? 'bg-blue-300 text-white' : 'hover:bg-sky-300'}`}
-                >
-                  {label}
-                </Link>
-              </li>
-            )
-          })}
-        </ul>
-      </div>
-      <p>
-        💛 Like this site? <a href="https://boosty.to/tarstars/donate" target="_blank">Make a donation via Boosty</a>
-      </p>
-      <Link
-        to={`${base}/alphabet`}
-        className="mt-6 block text-center bg-white text-blue-800 font-bold border border-blue-800 rounded py-3 hover:bg-blue-50"
+    <>
+      <nav
+        className={`fixed top-0 left-0 w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between
+        transform transition-transform duration-300 ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
       >
-        Start Learning
-      </Link>
-    </nav>
+        <div>
+          <Link to={base} className="block uppercase font-bold mb-4">
+            {t('welcome_title')}
+          </Link>
+          <select
+            className="mb-6 bg-sky-100 border rounded px-2 py-1 text-sm w-full"
+            value={lang}
+            onChange={(e) => setLang(e.target.value as 'en' | 'ru')}
+          >
+            <option value="en">EN</option>
+            <option value="ru">RU</option>
+          </select>
+          <ul className="space-y-2">
+            {items.map(({ to, label }) => {
+              const active = location.pathname === to
+              return (
+                <li key={to}>
+                  <Link
+                    to={to}
+                    className={`block px-3 py-2 rounded uppercase ${
+                      active ? 'bg-blue-300 text-white' : 'hover:bg-sky-300'
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+        <p>
+          💛 Like this site?{' '}
+          <a href="https://boosty.to/tarstars/donate" target="_blank">
+            Make a donation via Boosty
+          </a>
+        </p>
+        <Link
+          to={`${base}/alphabet`}
+          className="mt-6 block text-center bg-white text-blue-800 font-bold border border-blue-800 rounded py-3 hover:bg-blue-50"
+        >
+          Start Learning
+        </Link>
+      </nav>
+      <button
+        onClick={toggle}
+        className={`fixed top-4 z-40 bg-sky-200 text-blue-900 border border-blue-900 p-2 rounded-r transition-all ${
+          open ? 'left-64 -translate-x-full' : 'left-0'
+        }`}
+      >
+        {open ? '◀' : '▶'}
+      </button>
+    </>
   )
 }
+


### PR DESCRIPTION
## Summary
- Add state-managed SideNav that slides off screen and toggles with a button
- Adjust main content layout based on sidebar visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68908dab87448321b11b3cdfaa00e937