### PR TITLE
feat: show newest interesting notes first

### DIFF
--- a/frontend/src/pages/InterestingNotes.tsx
+++ b/frontend/src/pages/InterestingNotes.tsx
@@ -13,19 +13,20 @@ interface Note {
 
 const notes: Note[] = [
   {
-    dateKey: 'note_2025_06_17_date',
-    titleKey: 'note_2025_06_17_title',
+    dateKey: 'note_2025_07_07_date',
+    titleKey: 'note_2025_07_07_title',
     render: (t) => (
       <div className="grid md:grid-cols-2 gap-4 items-start">
         <img
-          src={architectImg}
-          alt={t('note_2025_06_17_alt')}
+          src={reptileImg}
+          alt={t('note_2025_07_07_alt')}
           className="w-full md:max-w-xs mx-auto"
         />
         <div className="space-y-4 text-lg">
-          <p>{t('note_2025_06_17_p1')}</p>
-          <p>{t('note_2025_06_17_p2')}</p>
-          <p>{t('note_2025_06_17_p3')}</p>
+          <p>{t('note_2025_07_07_p1')}</p>
+          <p>{t('note_2025_07_07_p2')}</p>
+          <p>{t('note_2025_07_07_p3')}</p>
+          <p>{t('note_2025_07_07_p4')}</p>
         </div>
       </div>
     ),
@@ -49,20 +50,19 @@ const notes: Note[] = [
     ),
   },
   {
-    dateKey: 'note_2025_07_07_date',
-    titleKey: 'note_2025_07_07_title',
+    dateKey: 'note_2025_06_17_date',
+    titleKey: 'note_2025_06_17_title',
     render: (t) => (
       <div className="grid md:grid-cols-2 gap-4 items-start">
         <img
-          src={reptileImg}
-          alt={t('note_2025_07_07_alt')}
+          src={architectImg}
+          alt={t('note_2025_06_17_alt')}
           className="w-full md:max-w-xs mx-auto"
         />
         <div className="space-y-4 text-lg">
-          <p>{t('note_2025_07_07_p1')}</p>
-          <p>{t('note_2025_07_07_p2')}</p>
-          <p>{t('note_2025_07_07_p3')}</p>
-          <p>{t('note_2025_07_07_p4')}</p>
+          <p>{t('note_2025_06_17_p1')}</p>
+          <p>{t('note_2025_06_17_p2')}</p>
+          <p>{t('note_2025_06_17_p3')}</p>
         </div>
       </div>
     ),


### PR DESCRIPTION
## Summary
- display interesting notes in reverse chronological order so the newest story appears first

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891cb01534c83219bfd6aec1f40379d