### PR TITLE
Refine welcome page headings for consistency

### DIFF
--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -6,6 +6,13 @@ import Meta from '../components/Meta'
 
 export default function WelcomePage() {
   const { t, lang } = useLanguage()
+  const styles = {
+    h1: 'text-4xl font-bold',
+    h2: 'text-3xl font-bold',
+    h3: 'text-2xl font-bold',
+    h4: 'text-xl font-bold',
+    li: 'text-xl text-left max-w-prose',
+  }
   return (
     <>
       <Meta />
@@ -27,42 +34,44 @@ export default function WelcomePage() {
 
         {lang === 'ru' ? (
           <>
-            <h1 className="text-4xl font-bold">
-              Пет проект Алины Бродецкой
-            </h1>
+            <h1 className={styles.h1}>Пет проект Алины Бродецкой</h1>
 
-            <h2 className="text-2xl font-bold">Из чего состоит</h2>
-            <h3>Тренажеры</h3>
+            <h2 className={styles.h2}>Из чего состоит</h2>
+            <h3 className={styles.h3}>Тренажеры</h3>
             <ul>
-              <li className="text-2xl text-left max-w-prose">Тренажер алфавита</li>
-              <li className="text-2xl text-left max-w-prose">Тренажер частотных слов</li>
-              <li className="text-2xl text-left max-w-prose">Тренажер частотных фраз</li>
-              <li className="text-2xl text-left max-w-prose">Учимся по вывескам</li>
+              <li className={styles.li}>Тренажер алфавита</li>
+              <li className={styles.li}>Тренажер частотных слов</li>
+              <li className={styles.li}>Тренажер частотных фраз</li>
+              <li className={styles.li}>Учимся по вывескам</li>
             </ul>
-            <h3>Про жизнь в Армении</h3>
+            <h3 className={styles.h3}>Про жизнь в Армении</h3>
             <ul>
-              <li className="text-2xl text-left max-w-prose">
-                <h4>Проверенные водители</h4>
-                По <a href="/ru/drivers">ссылке</a> – водители, которых одобрили мы
-                или наше комьюнити. Присоединяйтесь – поделимся контактами.
+              <li className={styles.li}>
+                <h4 className={styles.h4}>Проверенные водители</h4>
+                <p>
+                  По <a href="/ru/drivers">ссылке</a> – водители, которых одобрили мы
+                  или наше комьюнити. Присоединяйтесь – поделимся контактами.
+                </p>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4>Места и истории Еревана и Армении</h4>
-                По <a href="/ru/alphabet">ссылке</a> – заметки про Ереван и Армению
+              <li className={styles.li}>
+                <h4 className={styles.h4}>Места и истории Еревана и Армении</h4>
+                <p>
+                  По <a href="/ru/alphabet">ссылке</a> – заметки про Ереван и Армению
+                </p>
               </li>
             </ul>
 
-            <h2 className="text-2xl font-bold">Как пользоваться тренажерами</h2>
+            <h2 className={styles.h2}>Как пользоваться тренажерами</h2>
             <ul>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Тренажер алфавита</h4>
-                <ul>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Тренажер алфавита</h3>
+                <ul className="list-disc pl-6">
                   <li>
                     Переходим по <a href="/ru/alphabet">ссылке</a>
                   </li>
                   <li>
-                    Выбираем букву, которую хотим потренировать, щёлкаем на
-                    неё в алфавите.
+                    Выбираем букву, которую хотим потренировать, щёлкаем на неё
+                    в алфавите.
                   </li>
                   <li>
                     Смотрим, как выглядит прописное и строчное написание буквы,
@@ -70,18 +79,18 @@ export default function WelcomePage() {
                   </li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Тренажер частотных слов</h4>
-                <ul>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Тренажер частотных слов</h3>
+                <ul className="list-disc pl-6">
                   <li>
                     Переходим по <a href="/ru/words">ссылке</a>
                   </li>
                   <li>Разглядываем картинки, запоминаем слова.</li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Тренажер частотных фраз</h4>
-                <ul>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Тренажер частотных фраз</h3>
+                <ul className="list-disc pl-6">
                   <li>
                     Переходим по <a href="/ru/phrases">ссылке</a>
                   </li>
@@ -91,9 +100,9 @@ export default function WelcomePage() {
                   </li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Учимся по вывескам</h4>
-                <ul>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Учимся по вывескам</h3>
+                <ul className="list-disc pl-6">
                   <li>
                     Переходим по <a href="/ru/plaques">ссылке</a>
                   </li>
@@ -107,77 +116,68 @@ export default function WelcomePage() {
           </>
         ) : (
           <>
-            <h1 className="text-4xl font-bold">
-              Alina Brodetskaya's pet project
-            </h1>
+            <h1 className={styles.h1}>Alina Brodetskaya's pet project</h1>
 
-            <h2 className="text-2xl font-bold">What it includes</h2>
-            <h3>Trainers</h3>
+            <h2 className={styles.h2}>What it includes</h2>
+            <h3 className={styles.h3}>Trainers</h3>
             <ul>
-              <li className="text-2xl text-left max-w-prose">Alphabet trainer</li>
-              <li className="text-2xl text-left max-w-prose">Frequent words trainer</li>
-              <li className="text-2xl text-left max-w-prose">Frequent phrases trainer</li>
-              <li className="text-2xl text-left max-w-prose">Learning through signs</li>
+              <li className={styles.li}>Alphabet trainer</li>
+              <li className={styles.li}>Frequent words trainer</li>
+              <li className={styles.li}>Frequent phrases trainer</li>
+              <li className={styles.li}>Learning through signs</li>
             </ul>
-            <h3>About life in Armenia</h3>
+            <h3 className={styles.h3}>About life in Armenia</h3>
             <ul>
-              <li className="text-2xl text-left max-w-prose">
-                <h4>Reliable drivers</h4>
-                At the <a href="/en/drivers">link</a> you'll find drivers approved
-                by us or our community. Join us and we'll share their contacts.
+              <li className={styles.li}>
+                <h4 className={styles.h4}>Reliable drivers</h4>
+                <p>
+                  At the <a href="/en/drivers">link</a> you'll find drivers approved
+                  by us or our community. Join us and we'll share their contacts.
+                </p>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4>Places and stories of Yerevan and Armenia</h4>
-                Follow the <a href="/en/alphabet">link</a> for notes about Yerevan
-                and Armenia.
+              <li className={styles.li}>
+                <h4 className={styles.h4}>Places and stories of Yerevan and Armenia</h4>
+                <p>
+                  Follow the <a href="/en/alphabet">link</a> for notes about Yerevan
+                  and Armenia.
+                </p>
               </li>
             </ul>
 
-            <h2 className="text-2xl font-bold">How to use the trainers</h2>
+            <h2 className={styles.h2}>How to use the trainers</h2>
             <ul>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Alphabet trainer</h4>
-                <ul>
-                  <li>
-                    Go to the <a href="/en/alphabet">link</a>
-                  </li>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Alphabet trainer</h3>
+                <ul className="list-disc pl-6">
+                  <li>Go to the <a href="/en/alphabet">link</a></li>
                   <li>
                     Select the letter you want to practise and click it in the
                     alphabet.
                   </li>
-                  <li>
-                    See the uppercase and lowercase forms and hear how it
-                    sounds.
-                  </li>
+                  <li>See the uppercase and lowercase forms and hear how it sounds.</li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Frequent words trainer</h4>
-                <ul>
-                  <li>
-                    Go to the <a href="/en/words">link</a>
-                  </li>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Frequent words trainer</h3>
+                <ul className="list-disc pl-6">
+                  <li>Go to the <a href="/en/words">link</a></li>
                   <li>Look at the pictures and memorise the words.</li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Frequent phrases trainer</h4>
-                <ul>
-                  <li>
-                    Go to the <a href="/en/phrases">link</a>
-                  </li>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Frequent phrases trainer</h3>
+                <ul className="list-disc pl-6">
+                  <li>Go to the <a href="/en/phrases">link</a></li>
                   <li>
                     Look at the pictures, remember frequent phrases and use the
                     transcription to check pronunciation.
                   </li>
                 </ul>
               </li>
-              <li className="text-2xl text-left max-w-prose">
-                <h4 className="underline">Learning through signs</h4>
-                <ul>
-                  <li>
-                    Go to the <a href="/en/plaques">link</a>
-                  </li>
+              <li className={styles.li}>
+                <h3 className={`${styles.h3} underline`}>Learning through signs</h3>
+                <ul className="list-disc pl-6">
+                  <li>Go to the <a href="/en/plaques">link</a></li>
                   <li>
                     Study bilingual signs, learn letter pronunciation and read
                     notes about the signs.
@@ -187,9 +187,6 @@ export default function WelcomePage() {
             </ul>
           </>
         )}
-
-        <h1 className="text-4xl font-bold">{t('welcome_title')}</h1>
-        <p className="text-2xl text-left max-w-prose">{t('welcome_desc')}</p>
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- harmonize `<h1>`-`<h4>` styles via shared class map
- reorganize Russian and English welcome text with proper nesting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689313477fe48321b584c301fa864050