### PR TITLE
Improve LetterModal responsiveness

### DIFF
--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -31,77 +31,89 @@ export default function LetterModal({ info, onClose }: LetterModalProps) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded p-4 max-w-sm w-full shadow-lg"
+        className="bg-white rounded p-4 max-w-sm w-11/12 shadow-lg max-h-[90vh] overflow-y-auto relative"
         onClick={(e) => e.stopPropagation()}
       >
-        <button className="float-right" onClick={onClose}>
+        <button className="absolute top-2 right-2" onClick={onClose}>
           ✕
         </button>
         <table className="table-auto border-collapse w-full text-center">
           <tbody>
             <tr>
-              <td colSpan={maxLen} className="p-2">
+              <td colSpan={maxLen} className="p-1 sm:p-2">
                 <img src={info.image} alt="" className="w-full h-auto" />
               </td>
             </tr>
             <tr>
-              <td colSpan={maxLen} className="border px-2 py-1 text-2xl text-center">
+              <td
+                colSpan={maxLen}
+                className="border px-1 py-1 text-lg text-center sm:px-2 sm:text-xl"
+              >
                 {info.wordUpper.join('')}
               </td>
             </tr>
             <tr>
-              <td colSpan={maxLen} className="border px-2 py-1 text-2xl text-center">
+              <td
+                colSpan={maxLen}
+                className="border px-1 py-1 text-lg text-center sm:px-2 sm:text-xl"
+              >
                 {info.wordLower.join('')}
               </td>
             </tr>
             <tr>
-              <td colSpan={maxLen} className="border px-2 py-1 text-center">
+              <td colSpan={maxLen} className="border px-1 py-1 text-center sm:px-2">
                 {(info.soundRu ?? []).join('')}
               </td>
             </tr>
             <tr>
-              <td colSpan={maxLen} className="border px-2 py-1 text-center">
+              <td colSpan={maxLen} className="border px-1 py-1 text-center sm:px-2">
                 {(info.soundEn ?? []).join('')}
               </td>
             </tr>
             <tr>
               {info.wordUpper.map((l, i) => (
-                <td key={`su${i}`} className="border px-2 py-1 text-2xl">
+                <td
+                  key={`su${i}`}
+                  className="border px-1 py-1 text-lg sm:px-2 sm:text-xl"
+                >
                   {l}
                 </td>
               ))}
             </tr>
             <tr>
               {info.wordLower.map((l, i) => (
-                <td key={`sl${i}`} className="border px-2 py-1 text-2xl">
+                <td
+                  key={`sl${i}`}
+                  className="border px-1 py-1 text-lg sm:px-2 sm:text-xl"
+                >
                   {l}
                 </td>
               ))}
             </tr>
             <tr>
               {ruCaps.map((s, i) => (
-                <td key={`sr${i}`} className="border px-2 py-1">
+                <td key={`sr${i}`} className="border px-1 py-1 sm:px-2">
                   {s}
                 </td>
               ))}
             </tr>
             <tr>
               {enCaps.map((s, i) => (
-                <td key={`se${i}`} className="border px-2 py-1">
+                <td key={`se${i}`} className="border px-1 py-1 sm:px-2">
                   {s}
                 </td>
               ))}
             </tr>
             {info.wordRu && (
               <tr>
-                <td colSpan={maxLen} className="border px-2 py-1 text-center">
+                <td colSpan={maxLen} className="border px-1 py-1 text-center sm:px-2">
                   {info.wordRu}
                 </td>
               </tr>
             )}
             {info.wordEn && (
               <tr>
-                <td colSpan={maxLen} className="border px-2 py-1 text-center">
+                <td colSpan={maxLen} className="border px-1 py-1 text-center sm:px-2">
                   {info.wordEn}
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- Make LetterModal container scrollable with fixed height and 11/12 width
- Reposition close button to fixed top-right of modal
- Reduce table padding and font size on small screens for better fit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68983d4a6e1c8321afbf19960c33c69d