### PR TITLE
Route all locales through single index and localize meta tags

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,14 @@
     ],
     "rewrites": [
       {
+        "source": "/ru/**",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/en/**",
+        "destination": "/index.html"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/frontend/src/components/Meta.tsx
+++ b/frontend/src/components/Meta.tsx
@@ -7,13 +7,38 @@ export default function Meta() {
   const location = useLocation()
   const path = location.pathname.replace(/^\/(en|ru)/, '') || '/'
   const canonical = `https://am-lang.web.app/${lang}${path}`
+  const meta = {
+    en: {
+      title: 'Armenian Language Tools',
+      description:
+        'Learn Armenian alphabet, words and phrases with pronunciation for English and Russian speakers.',
+      keywords:
+        'Armenian language, learn Armenian, Armenian alphabet, Armenian words, Armenian phrases',
+    },
+    ru: {
+      title: 'Тренажеры армянского языка',
+      description:
+        'Изучайте армянский алфавит, слова и фразы с произношением для русско- и англоговорящих.',
+      keywords:
+        'армянский язык, изучение армянского, армянский алфавит, армянские слова, армянские фразы',
+    },
+  } as const
+  const current = meta[lang]
   const en = `https://am-lang.web.app/en${path}`
   const ru = `https://am-lang.web.app/ru${path}`
   return (
-    <Helmet>
+    <Helmet htmlAttributes={{ lang }}>
+      <title>{current.title}</title>
       <link rel="canonical" href={canonical} />
       <link rel="alternate" href={en} hrefLang="en" />
       <link rel="alternate" href={ru} hrefLang="ru" />
+      <meta name="description" content={current.description} />
+      <meta name="keywords" content={current.keywords} />
+      <meta property="og:title" content={current.title} />
+      <meta property="og:description" content={current.description} />
+      <meta property="og:image" content="/favicon.ico" />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:type" content="website" />
     </Helmet>
   )
 }


### PR DESCRIPTION
## Summary
- Rewrite Firebase hosting to send both /ru/** and /en/** routes to a single index.html
- Localize HTML metadata with lang, description, keywords and Open Graph tags based on the current language
- Build uses a single template without copying a Russian-specific index

## Testing
- `npm --prefix frontend test` (fails: Missing script)
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_689870d808488321b209dec304ef6ee6