### PR TITLE
fix: allow language-specific meta description

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,24 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Learn Armenian alphabet, words and phrases with pronunciation for English and Russian speakers." />
-    <meta name="keywords" content="Armenian language, learn Armenian, Armenian alphabet, Armenian words, Armenian phrases" />
     <meta name="robots" content="index, follow" />
     <title>Armenian Language Tools</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-
-    <!-- Open Graph for social media -->
-    <meta property="og:title" content="Armenian Language Tools" />
-    <meta property="og:description" content="Interactive Armenian language trainers for alphabet, words and phrases." />
-    <meta property="og:image" content="/favicon.ico" />
-    <meta property="og:url" content="https://am-lang.web.app" />
-    <meta property="og:type" content="website" />
-
-    <!-- Twitter card -->
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Armenian Language Tools" />
-    <meta name="twitter:description" content="Learn Armenian with visual tools and pronunciation support." />
-    <meta name="twitter:image" content="/favicon.ico" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove static meta tags from index.html so React Helmet can manage language-specific metadata

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689874f0ff6c8321a136afebfd3e7bdb