### PR TITLE
Add bilingual signs section with Hrazdan example

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import PhrasesPage from './pages/PhrasesPage'
 import InterestingNotes from './pages/InterestingNotes'
 import ReliableDriversPage from './pages/ReliableDriversPage'
 import SmallEtudes from './pages/SmallEtudes'
+import BilingualSigns from './pages/BilingualSigns'
 import { LanguageProvider } from './useLanguage'
 import SideNav from './components/SideNav'
 import './index.css'
@@ -30,6 +31,7 @@ export default function App() {
               <Route path="/:lang/phrases" element={<PhrasesPage />} />
               <Route path="/:lang/drivers" element={<ReliableDriversPage />} />
               <Route path="/:lang/interesting_notes" element={<InterestingNotes />} />
+              <Route path="/:lang/bilingual_signs" element={<BilingualSigns />} />
               <Route path="/:lang/small_etudes" element={<SmallEtudes />} />
               <Route path="*" element={<Navigate to="/en" replace />} />
             </Routes>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,6 +13,7 @@ export default function NavBar() {
         <Link to={`/${lang}/words`}>{t('nav_words')}</Link>
         <Link to={`/${lang}/phrases`}>{t('nav_phrases')}</Link>
         <Link to={`/${lang}/interesting_notes`}>{t('nav_interesting_notes')}</Link>
+        <Link to={`/${lang}/bilingual_signs`}>{t('nav_bilingual_signs')}</Link>
       </nav>
       <select
         className="border px-2 py-1"

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -19,6 +19,7 @@ export default function SideNav({ open, toggle }: SideNavProps) {
     { to: `${base}/drivers`, label: t('nav_drivers') },
     { to: `${base}/small_etudes`, label: t('nav_small_etudes') },
     { to: `${base}/interesting_notes`, label: t('nav_interesting_notes') },
+    { to: `${base}/bilingual_signs`, label: t('nav_bilingual_signs') },
   ]
 
   return (

--- a/frontend/src/pages/BilingualSigns.tsx
+++ b/frontend/src/pages/BilingualSigns.tsx
@@ -1,0 +1,78 @@
+import { useLanguage, type Lang } from '../useLanguage'
+import Meta from '../components/Meta'
+import hrazdanImg from '../assets/bilingual/hrazdan.webp'
+import type { ReactNode } from 'react'
+
+interface Sign {
+  dateKey: string
+  titleKey: string
+  render: (t: (key: string) => string, lang: Lang) => ReactNode
+}
+
+const signs: Sign[] = [
+  {
+    dateKey: 'sign_2025_07_20_date',
+    titleKey: 'sign_2025_07_20_title',
+    render: (t, lang) => {
+      const translit =
+        lang === 'ru'
+          ? ['', 'р', 'а', 'з', 'д', 'а', 'н']
+          : ['', 'r', 'a', 'z', 'd', 'a', 'n']
+      const armenian = ['Հ', 'Ր', 'Ա', 'Զ', 'Դ', 'Ա', 'Ն']
+      return (
+        <div className="grid md:grid-cols-2 gap-4 items-start">
+          <img
+            src={hrazdanImg}
+            alt={t('sign_2025_07_20_alt')}
+            className="w-full md:max-w-xs mx-auto"
+          />
+          <div className="space-y-4 text-lg">
+            <p>{t('sign_2025_07_20_p1')}</p>
+            <p>{t('sign_2025_07_20_p2')}</p>
+            <table className="table-auto border-collapse mt-4">
+              <tbody>
+                <tr>
+                  {armenian.map((l, i) => (
+                    <td key={i} className="border px-2 py-1">
+                      {l}
+                    </td>
+                  ))}
+                </tr>
+                <tr>
+                  {translit.map((l, i) => (
+                    <td key={i} className="border px-2 py-1">
+                      {l}
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )
+    },
+  },
+]
+
+export default function BilingualSigns() {
+  const { t, lang } = useLanguage()
+  return (
+    <>
+      <Meta />
+      <div className="p-4">
+        <h1 className="text-xl font-bold mb-4">{t('bilingual_signs_title')}</h1>
+        <p className="mb-6">{t('bilingual_signs_intro')}</p>
+        <ul className="space-y-8">
+          {signs.map((sign) => (
+            <li key={sign.titleKey} className="space-y-2">
+              <h2 className="text-lg font-semibold">
+                {t(sign.dateKey)} - {t(sign.titleKey)}
+              </h2>
+              <div>{sign.render(t, lang)}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/useLanguage.tsx
+++ b/frontend/src/useLanguage.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-type Lang = 'en' | 'ru'
+export type Lang = 'en' | 'ru'
 interface I18n {
   lang: Lang
   setLang: (l: Lang) => void
@@ -18,6 +18,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_drivers: 'Reliable drivers',
     nav_small_etudes: 'Small etudes',
     nav_interesting_notes: 'Interesting notes',
+    nav_bilingual_signs: 'Bilingual signs',
     alphabet_title: 'Armenian Alphabet',
     words_title: 'Simple Words',
     phrases_title: 'Frequent Phrases',
@@ -34,12 +35,22 @@ const strings: Record<Lang, Record<string, string>> = {
       'Short notes and tiny programs about JavaScript.',
     interesting_notes_intro:
       'Here one can find interesting notes about Yerevan, Armenia, language and life.',
+    bilingual_signs_intro:
+      'Examples of Armenian signs with Russian or English transliteration.',
     letter: 'Letter',
     latin: 'Latin',
     russian: 'Russian phonetic',
     lowercase: 'Lowercase',
     small_etudes_title: 'Small etudes',
     interesting_notes_title: 'Interesting notes',
+    bilingual_signs_title: 'Bilingual signs',
+    sign_2025_07_20_date: '20 Jul 2025',
+    sign_2025_07_20_title: 'Hrazdan railroad station',
+    sign_2025_07_20_alt: 'Hrazdan railroad station sign',
+    sign_2025_07_20_p1:
+      'In Armenia, many signs are also translated into Russian or English. This is a surprisingly good way to learn the Armenian alphabet. Today we want to share with you a picture we took at the Hrazdan railway station. This place is not widely known as a tourist attraction but nevertheless has its own charm. Later we will share more photos of this place.',
+    sign_2025_07_20_p2:
+      'Below is a table showing the correspondence between the Armenian name ՀՐԱԶԴԱՆ and its Latin transliteration “hrazdan.” Here one can see that the letter Հ (H) is not pronounced in this context, Ր corresponds to “R,” Ա to “A,” Զ to “Z,” Դ to “D,” the second Ա again to “A,” and Ն to “N.”',
     note_2025_07_20_date: '20 Jul 2025',
     note_2025_07_20_title: 'Why JavaScript on a language site',
     note_2025_07_20_alt: 'Hrazdan Gorge in Yerevan',
@@ -109,6 +120,7 @@ const strings: Record<Lang, Record<string, string>> = {
     nav_drivers: 'Проверенные водители',
     nav_small_etudes: 'маленькие этюды',
     nav_interesting_notes: 'любопытные заметки',
+    nav_bilingual_signs: 'Двуязычные вывески',
     alphabet_title: 'Армянский алфавит',
     words_title: 'Простые слова',
     phrases_title: 'Частые фразы',
@@ -125,12 +137,22 @@ const strings: Record<Lang, Record<string, string>> = {
       'Короткие заметки о JavaScript и маленькие программки.',
     interesting_notes_intro:
       'Здесь можно найти любопытные заметки о Ереване, Армении, языке и жизни.',
+    bilingual_signs_intro:
+      'Примеры армянских вывесок с переводом на русский или английский.',
     letter: 'Буква',
     latin: 'Латиница',
     russian: 'Русская фонетика',
     lowercase: 'строчная',
     small_etudes_title: 'маленькие этюды',
     interesting_notes_title: 'любопытные заметки',
+    bilingual_signs_title: 'Двуязычные вывески',
+    sign_2025_07_20_date: '20 июля 2025',
+    sign_2025_07_20_title: 'Железнодорожная станция Раздан',
+    sign_2025_07_20_alt: 'вывеска железнодорожной станции Раздан',
+    sign_2025_07_20_p1:
+      'В Армении многие вывески продублированы на русском или английском. Это удивительно хороший способ выучить армянский алфавит. Сегодня мы хотим поделиться фотографией, сделанной на железнодорожной станции Раздан. Это место не является популярной туристической достопримечательностью, но всё же обладает своим шармом. Позже мы поделимся и другими фотографиями этого места.',
+    sign_2025_07_20_p2:
+      'Ниже приведена таблица соответствия между армянским названием ՀՐԱԶԴԱՆ и его русской транслитерацией «раздан». Видно, что буква Հ (H) здесь не произносится, Ր соответствует «Р», Ա — «А», Զ — «З», Դ — «Д», второе Ա снова «А», а Ն — «Н».',
     note_2025_07_20_date: '20 июля 2025',
     note_2025_07_20_title: 'Зачем JavaScript на языковом сайте',
     note_2025_07_20_alt: 'ущелье Раздана в Ереване',


### PR DESCRIPTION
## Summary
- add navigation and translations for new Bilingual signs section
- implement BilingualSigns page showing Hrazdan railroad station and letter mapping table
- link new section into site navigation and routing
- show Russian transliteration in Hrazdan example when Russian locale is active

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689b036e622c83219e9a495359bda3fb