### PR TITLE
Add authenticated print page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import InterestingNotes from './pages/InterestingNotes'
 import ReliableDriversPage from './pages/ReliableDriversPage'
 import SmallEtudes from './pages/SmallEtudes'
 import BilingualSigns from './pages/BilingualSigns'
+import PrintPage from './pages/PrintPage'
 import { LanguageProvider } from './useLanguage'
 import SideNav from './components/SideNav'
 import './index.css'
@@ -25,6 +26,7 @@ export default function App() {
           <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-64' : 'ml-0'}`}>
             <Routes>
               <Route path="/" element={<Navigate to="/en" replace />} />
+              <Route path="/print" element={<PrintPage />} />
               <Route path="/:lang" element={<WelcomePage />} />
               <Route path="/:lang/alphabet" element={<AlphabetPage />} />
               <Route path="/:lang/words" element={<WordsPage />} />

--- a/frontend/src/App_test_login.tsx
+++ b/frontend/src/App_test_login.tsx
@@ -50,8 +50,8 @@ export default function App() {
       } else {
         await signInWithEmailAndPassword(auth, email, pass);
       }
-    } catch (e: any) {
-      setErr(e.message ?? String(e));
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e));
     }
   }
 

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -32,8 +32,8 @@ export default function AuthPanel() {
       }
       setEmail("");
       setPass("");
-    } catch (e: any) {
-      setErr(e.message ?? String(e));
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e));
     }
   }
 

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -72,7 +72,7 @@ export default function SideNav({ open, toggle }: SideNavProps) {
         >
           Start Learning
         </Link>
-        <AuthPanel/>
+        <AuthPanel />
       </nav>
       <button
         onClick={toggle}

--- a/frontend/src/pages/PrintPage.tsx
+++ b/frontend/src/pages/PrintPage.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { collection, getDocs } from 'firebase/firestore'
+import { auth, db } from '../lib/firebase'
+import Meta from '../components/Meta'
+
+interface Card {
+  id: string
+  [key: string]: unknown
+}
+
+export default function PrintPage() {
+  const [cards, setCards] = useState<Card[]>([])
+  const [authorized, setAuthorized] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async (u) => {
+      if (!u) {
+        setAuthorized(false)
+        return
+      }
+      const snap = await getDocs(collection(db, 'cards'))
+      setCards(snap.docs.map((d) => ({ id: d.id, ...d.data() })))
+      setAuthorized(true)
+    })
+    return () => unsub()
+  }, [])
+
+  return (
+    <>
+      <Meta />
+      <div className="p-4 h-full overflow-y-auto">
+        {authorized ? (
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {cards.map((card) => (
+              <div key={card.id} className="border rounded p-2">
+                <pre className="whitespace-pre-wrap text-xs">
+                  {JSON.stringify(card, null, 2)}
+                </pre>
+              </div>
+            ))}
+          </div>
+        ) : authorized === false ? (
+          <p>you are to be authorized to use this function</p>
+        ) : null}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/print` route to list card data for authenticated users
- rely on existing auth panel and show message for unauthorized visitors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b38a0d9f883219ea1e1aaba65f98b