### PR TITLE
Add card selection and PDF download

### DIFF
--- a/frontend/src/lib/printCards.ts
+++ b/frontend/src/lib/printCards.ts
@@ -1,0 +1,15 @@
+export default function printCards(nodes: HTMLElement[]) {
+  const printWindow = window.open('', '', 'width=800,height=600')
+  if (!printWindow) return
+  const doc = printWindow.document
+  doc.write('<html><head><title>Cards</title></head><body>')
+  nodes.forEach((node) => {
+    const clone = node.cloneNode(true) as HTMLElement
+    doc.body.appendChild(clone)
+  })
+  doc.write('</body></html>')
+  doc.close()
+  printWindow.focus()
+  printWindow.print()
+  printWindow.close()
+}

--- a/frontend/src/pages/PrintPage.tsx
+++ b/frontend/src/pages/PrintPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { onAuthStateChanged } from 'firebase/auth'
 import { collection, getDocs } from 'firebase/firestore'
 import { auth, db } from '../lib/firebase'
 import Meta from '../components/Meta'
+import printCards from '../lib/printCards'
 
 interface Card {
   id: string
@@ -12,6 +13,8 @@ interface Card {
 export default function PrintPage() {
   const [cards, setCards] = useState<Card[]>([])
   const [authorized, setAuthorized] = useState<boolean | null>(null)
+  const [selected, setSelected] = useState<string[]>([])
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({})
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (u) => {
@@ -26,20 +29,74 @@ export default function PrintPage() {
     return () => unsub()
   }, [])
 
+  const toggle = (id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    )
+  }
+
+  const selectAll = () => setSelected(cards.map((c) => c.id))
+  const clear = () => setSelected([])
+
+  const handleDownload = () => {
+    const nodes = selected
+      .map((id) => cardRefs.current[id])
+      .filter((n): n is HTMLElement => !!n)
+    if (nodes.length > 0) printCards(nodes)
+  }
+
   return (
     <>
       <Meta />
       <div className="p-4 h-full overflow-y-auto">
         {authorized ? (
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-            {cards.map((card) => (
-              <div key={card.id} className="border rounded p-2">
-                <pre className="whitespace-pre-wrap text-xs">
-                  {JSON.stringify(card, null, 2)}
-                </pre>
-              </div>
-            ))}
-          </div>
+          <>
+            <div className="mb-4 flex gap-2">
+              <button
+                type="button"
+                className="rounded bg-blue-500 px-2 py-1 text-white"
+                onClick={selectAll}
+              >
+                Select All
+              </button>
+              <button
+                type="button"
+                className="rounded bg-gray-500 px-2 py-1 text-white"
+                onClick={clear}
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                className="rounded bg-green-600 px-2 py-1 text-white disabled:opacity-50"
+                onClick={handleDownload}
+                disabled={selected.length === 0}
+              >
+                Download PDF
+              </button>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+              {cards.map((card) => (
+                <div
+                  key={card.id}
+                  ref={(el) => (cardRefs.current[card.id] = el)}
+                  className="border rounded p-2"
+                >
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(card.id)}
+                      onChange={() => toggle(card.id)}
+                      className="mt-1"
+                    />
+                    <pre className="whitespace-pre-wrap text-xs flex-1">
+                      {JSON.stringify(card, null, 2)}
+                    </pre>
+                  </label>
+                </div>
+              ))}
+            </div>
+          </>
         ) : authorized === false ? (
           <p>you are to be authorized to use this function</p>
         ) : null}


### PR DESCRIPTION
## Summary
- allow selecting cards on print page
- add Select All, Clear, and Download PDF actions
- implement printCards utility to render selected nodes for printing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3da1d0f08321957af6fd850c3329