### PR TITLE
Extract WordCard component from WordsPage

### DIFF
--- a/frontend/src/components/WordCard.tsx
+++ b/frontend/src/components/WordCard.tsx
@@ -1,0 +1,68 @@
+export interface Word {
+  image: string
+  wordUpper: string[]
+  wordLower: string[]
+  soundRu: string[]
+  soundEn: string[]
+  en: string
+  ru: string
+}
+
+interface WordCardProps {
+  word: Word
+  checked?: boolean
+  onToggle?: () => void
+}
+
+export default function WordCard({ word, checked, onToggle }: WordCardProps) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {checked !== undefined && onToggle && (
+        <input type="checkbox" checked={checked} onChange={onToggle} />
+      )}
+      <img src={word.image} alt={word.en} className="w-24 sm:w-32 md:w-40 h-auto" />
+      <table className="table-auto border-collapse">
+        <tbody>
+          <tr>
+            <td colSpan={word.wordUpper.length} className="border px-2 py-1 text-center">
+              {word.ru}
+            </td>
+          </tr>
+          <tr>
+            <td colSpan={word.wordUpper.length} className="border px-2 py-1 text-center">
+              {word.en}
+            </td>
+          </tr>
+          <tr>
+            {word.wordUpper.map((s, i) => (
+              <td key={`u-${i}`} className="border px-2 py-1 text-xl text-center">
+                {s}
+              </td>
+            ))}
+          </tr>
+          <tr>
+            {word.wordLower.map((s, i) => (
+              <td key={`l-${i}`} className="border px-2 py-1 text-xl text-center">
+                {s}
+              </td>
+            ))}
+          </tr>
+          <tr>
+            {word.soundRu.map((s, i) => (
+              <td key={`r-${i}`} className="border px-2 py-1 text-center">
+                {s.toUpperCase()}
+              </td>
+            ))}
+          </tr>
+          <tr>
+            {word.soundEn.map((s, i) => (
+              <td key={`e-${i}`} className="border px-2 py-1 text-center">
+                {s.toUpperCase()}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/pages/WordsPage.tsx
+++ b/frontend/src/pages/WordsPage.tsx
@@ -1,16 +1,7 @@
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import { rawWordInfoList } from '../data/rawWordInfoList'
-
-interface Word {
-  image: string
-  wordUpper: string[]
-  wordLower: string[]
-  soundRu: string[]
-  soundEn: string[]
-  en: string
-  ru: string
-}
+import WordCard, { Word } from '../components/WordCard'
 
 const selectedWordEns = new Set([
   'apple',
@@ -77,69 +68,13 @@ export default function WordsPage() {
     <>
       <Meta />
       <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">{t('words_title')}</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {words.map((w) => (
-          <div key={w.wordLower.join('')} className="flex flex-col items-center gap-2">
-            <img src={w.image} alt={w.en} className="w-24 sm:w-32 md:w-40 h-auto" />
-            <table className="table-auto border-collapse">
-              <tbody>
-                <tr>
-                  <td
-                    colSpan={w.wordUpper.length}
-                    className="border px-2 py-1 text-center"
-                  >
-                    {w.ru}
-                  </td>
-                </tr>
-                <tr>
-                  <td
-                    colSpan={w.wordUpper.length}
-                    className="border px-2 py-1 text-center"
-                  >
-                    {w.en}
-                  </td>
-                </tr>
-                <tr>
-                  {w.wordUpper.map((s, i) => (
-                    <td
-                      key={`u-${i}`}
-                      className="border px-2 py-1 text-xl text-center"
-                    >
-                      {s}
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  {w.wordLower.map((s, i) => (
-                    <td
-                      key={`l-${i}`}
-                      className="border px-2 py-1 text-xl text-center"
-                    >
-                      {s}
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  {w.soundRu.map((s, i) => (
-                    <td key={`r-${i}`} className="border px-2 py-1 text-center">
-                      {s.toUpperCase()}
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  {w.soundEn.map((s, i) => (
-                    <td key={`e-${i}`} className="border px-2 py-1 text-center">
-                      {s.toUpperCase()}
-                    </td>
-                  ))}
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        ))}
+        <h1 className="text-xl font-bold mb-4">{t('words_title')}</h1>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {words.map((w) => (
+            <WordCard key={w.wordLower.join('')} word={w} />
+          ))}
+        </div>
       </div>
-    </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- move word card markup into new `WordCard` component
- render an optional checkbox for word selection
- update `WordsPage` to use `WordCard`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b530e5cc08321993db376bdce714a