### PR TITLE
Improve print card printing to include styles and wait for load

### DIFF
--- a/frontend/src/lib/printCards.ts
+++ b/frontend/src/lib/printCards.ts
@@ -1,15 +1,35 @@
 export default function printCards(nodes: HTMLElement[]) {
   const printWindow = window.open('', '', 'width=800,height=600')
   if (!printWindow) return
-  const doc = printWindow.document
-  doc.write('<html><head><title>Cards</title></head><body>')
-  nodes.forEach((node) => {
-    const clone = node.cloneNode(true) as HTMLElement
-    doc.body.appendChild(clone)
+
+  printWindow.addEventListener('load', () => {
+    printWindow.focus()
+    printWindow.print()
+    printWindow.close()
   })
-  doc.write('</body></html>')
+
+  const base = `<base href="${location.origin}/">`
+  const headStyles = Array.from(
+    document.head.querySelectorAll('link[rel="stylesheet"], style')
+  )
+    .map((el) => el.outerHTML)
+    .join('')
+
+  const body = nodes
+    .map((node) => {
+      const clone = node.cloneNode(true) as HTMLElement
+      clone.querySelectorAll('img').forEach((img) => {
+        const src = img.getAttribute('src')
+        if (src) img.src = new URL(src, location.origin).href
+      })
+      return clone.outerHTML
+    })
+    .join('')
+
+  const doc = printWindow.document
+  doc.open()
+  doc.write(
+    `<html><head><title>Cards</title>${base}${headStyles}</head><body>${body}</body></html>`
+  )
   doc.close()
-  printWindow.focus()
-  printWindow.print()
-  printWindow.close()
 }


### PR DESCRIPTION
## Summary
- Copy stylesheet and style tags plus base URL into card print window
- Normalize cloned images, avoid mutating originals via `outerHTML`
- Trigger printing only after window load event to ensure assets are ready

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b6249271c8321866b629bdcabfd1e