### PR TITLE
feat: add global boar mascot with random phrase bubble

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import BilingualSigns from './pages/BilingualSigns'
 import PrintPage from './pages/PrintPage'
 import { LanguageProvider } from './useLanguage'
 import SideNav from './components/SideNav'
+import Boar from './components/Boar'
 import './index.css'
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
     <BrowserRouter>
       <LanguageProvider>
         <TrackPageViews />
+        <Boar />
         <div className="flex min-h-screen">
           {/** Side navigation with slide toggle **/}
           <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} />

--- a/frontend/src/components/Boar.tsx
+++ b/frontend/src/components/Boar.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import boarImg from '../assets/little-boar400x600.webp'
+import telegramLogo from '../assets/telegram_logo.svg'
+import { useLanguage, Lang } from '../useLanguage'
+
+const phrases: Record<Lang, string[]> = {
+  en: ['Hi there!', 'Have fun!', 'Keep learning!'],
+  ru: ['Привет!', 'Хорошего дня!', 'Учите армянский!']
+}
+
+export default function Boar() {
+  const { lang, t } = useLanguage()
+  const [phrase, setPhrase] = useState('')
+
+  useEffect(() => {
+    const list = phrases[lang]
+    setPhrase(list[Math.floor(Math.random() * list.length)])
+  }, [lang])
+
+  return (
+    <div className="fixed right-2 bottom-2 z-50 w-24 sm:w-32 md:w-40 text-center">
+      <div className="relative">
+        <img src={boarImg} alt="Little boar" className="w-full" />
+        <div className="absolute -top-20 left-1/2 -translate-x-1/2">
+          <div className="relative bg-white border border-gray-300 rounded-lg px-2 py-1 text-xs shadow">
+            {phrase}
+            <svg viewBox="0 0 20 10" className="absolute -bottom-2 left-1/2 -translate-x-1/2" width="20" height="10">
+              <polygon points="0,0 20,0 10,10" className="fill-white stroke-gray-300" />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <p className="-mt-4 text-sm">
+        <a
+          href="https://t.me/alina_yerevan_js"
+          target="_blank"
+          rel="noopener"
+          className="inline-flex items-center gap-1"
+        >
+          <img src={telegramLogo} alt="Telegram icon" width="20" />
+          {t('join_telegram')}
+        </a>
+      </p>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,11 +1,9 @@
 import araratImg from '../assets/ararat.webp'
-import boarImg from '../assets/little-boar400x600.webp'
-import telegramLogo from '../assets/telegram_logo.svg'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 
 export default function WelcomePage() {
-  const { t, lang } = useLanguage()
+  const { lang } = useLanguage()
   const styles = {
     h1: 'text-4xl font-bold',
     h2: 'text-2xl font-bold',
@@ -19,19 +17,6 @@ export default function WelcomePage() {
       <Meta />
       <div className="relative flex flex-col items-center gap-4 p-4">
         <img src={araratImg} alt="Mount Ararat" className="w-320 rounded" />
-        <div className="fixed right-4 bottom-4 w-40">
-          <img src={boarImg} alt="Little boar" />
-          <p className="relative -top-7">
-            <a
-              href="https://t.me/alina_yerevan_js"
-              target="_blank"
-              rel="noopener"
-            >
-              <img src={telegramLogo} alt="Telegram icon" width="20" />
-              {t('join_telegram')}
-            </a>
-          </p>
-        </div>
 
         {lang === 'ru' ? (
           <>


### PR DESCRIPTION
## Summary
- show boar mascot on every page
- add speech bubble with random friendly phrase
- make mascot responsive on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9945d66883218b508e4a7feb8180