### PR TITLE
Hide nav toggle during alphabet modal and default nav closed

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,8 @@ import Boar from './components/Boar'
 import './index.css'
 
 export default function App() {
-  const [navOpen, setNavOpen] = useState(true)
+  const [navOpen, setNavOpen] = useState(false)
+  const [hideToggle, setHideToggle] = useState(false)
   return (
     <BrowserRouter>
       <LanguageProvider>
@@ -24,13 +25,13 @@ export default function App() {
         <Boar />
         <div className="flex min-h-screen">
           {/** Side navigation with slide toggle **/}
-          <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} />
+          <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} hideToggle={hideToggle} />
           <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-64' : 'ml-0'}`}>
             <Routes>
               <Route path="/" element={<Navigate to="/en" replace />} />
               <Route path="/print" element={<PrintPage />} />
               <Route path="/:lang" element={<WelcomePage />} />
-              <Route path="/:lang/alphabet" element={<AlphabetPage />} />
+              <Route path="/:lang/alphabet" element={<AlphabetPage onModalToggle={setHideToggle} />} />
               <Route path="/:lang/words" element={<WordsPage />} />
               <Route path="/:lang/phrases" element={<PhrasesPage />} />
               <Route path="/:lang/drivers" element={<ReliableDriversPage />} />

--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -27,7 +27,7 @@ export default function LetterModal({ info, onClose }: LetterModalProps) {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
       onClick={onClose}
     >
       <div

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -5,9 +5,10 @@ import AuthPanel from "../components/AuthPanel";
 interface SideNavProps {
   open: boolean
   toggle: () => void
+  hideToggle?: boolean
 }
 
-export default function SideNav({ open, toggle }: SideNavProps) {
+export default function SideNav({ open, toggle, hideToggle }: SideNavProps) {
   const { lang, setLang, t } = useLanguage()
   const location = useLocation()
 
@@ -75,14 +76,16 @@ export default function SideNav({ open, toggle }: SideNavProps) {
         </Link>
         <AuthPanel />
       </nav>
-      <button
-        onClick={toggle}
-        className={`fixed top-12 z-40 bg-sky-200 text-blue-900 border-blue-900 p-1 rounded-r transition-all ${
-          open ? 'left-64 -translate-x-full' : 'left-0'
-        }`}
-      >
-        {open ? '◀' : '▶'}
-      </button>
+      {!hideToggle && (
+        <button
+          onClick={toggle}
+          className={`fixed top-12 z-40 bg-sky-200 text-blue-900 border-blue-900 p-1 rounded-r transition-all ${
+            open ? 'left-64 -translate-x-full' : 'left-0'
+          }`}
+        >
+          {open ? '◀' : '▶'}
+        </button>
+      )}
     </>
   )
 }

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import LetterModal from '../components/LetterModal'
@@ -64,9 +64,23 @@ const letterSoundMap: Record<string, { en: string; ru: string }> = Object.fromEn
   letters.map(([upper, , en, ru]) => [upper, { en, ru }])
 )
 
-export default function AlphabetPage() {
+interface AlphabetPageProps {
+  onModalToggle?: (hidden: boolean) => void
+}
+
+export default function AlphabetPage({ onModalToggle }: AlphabetPageProps) {
   const { t } = useLanguage()
   const [active, setActive] = useState<WordInfo | null>(null)
+
+  useEffect(() => {
+    onModalToggle?.(active !== null)
+  }, [active, onModalToggle])
+
+  useEffect(() => {
+    return () => {
+      onModalToggle?.(false)
+    }
+  }, [onModalToggle])
 
   const openInfo = (letter: string) => {
     const infoList = wordInfoMap[letter]


### PR DESCRIPTION
## Summary
- Hide side navigation toggle when alphabet modal is open
- Set side navigation panel to be hidden by default
- Ensure alphabet modal overlays other UI elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ca0b1d57c8321b0139d88a3a92ec6