### PR TITLE
feat: add travel request link to drivers page

### DIFF
--- a/frontend/src/pages/ReliableDriversPage.tsx
+++ b/frontend/src/pages/ReliableDriversPage.tsx
@@ -44,6 +44,16 @@ export default function ReliableDriversPage() {
       <Meta />
       <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{t('drivers_title')}</h1>
+      <p className="mb-4">
+        <a
+          href="https://t.me/yourgroup/12345?utm_source=site&utm_medium=cta&utm_campaign=rides"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-lg text-blue-600 underline"
+        >
+          {t('drivers_leave_request')}
+        </a>
+      </p>
       <table className="table-auto border-collapse w-full">
         <thead>
           <tr>

--- a/frontend/src/useLanguage.tsx
+++ b/frontend/src/useLanguage.tsx
@@ -111,6 +111,7 @@ const strings: Record<Lang, Record<string, string>> = {
     drivers_col_cars: 'Available cars',
     drivers_col_phones: 'Phones',
     drivers_col_site: 'Website',
+    drivers_leave_request: 'Leave a travel request in Telegram',
   },
   ru: {
     welcome_title: 'Добро пожаловать в тренажеры армянского языка',
@@ -214,6 +215,7 @@ const strings: Record<Lang, Record<string, string>> = {
     drivers_col_cars: 'Доступные машины',
     drivers_col_phones: 'Телефоны',
     drivers_col_site: 'Сайт',
+    drivers_leave_request: 'Оставить заявку на поездку в Telegram',
   },
 }
 


### PR DESCRIPTION
## Summary
- add Telegram call-to-action link to Reliable Drivers page
- localize CTA text for English and Russian

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da9ffa7f48321ae2dea4ddb660442