### PR TITLE
fix: remove black overlay in vocabulary popup

### DIFF
--- a/frontend/src/components/LetterModal.tsx
+++ b/frontend/src/components/LetterModal.tsx
@@ -27,7 +27,7 @@ export default function LetterModal({ info, onClose }: LetterModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      className="fixed inset-0 z-50 flex items-center justify-center"
       onClick={onClose}
     >
       <div


### PR DESCRIPTION
## Summary
- remove dark background when letter modal is active so training page stays visible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db1e171a88321af410f84fd2f9dd2