### PR TITLE
Keep navigation toggle visible

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import './index.css'
 
 export default function App() {
   const [navOpen, setNavOpen] = useState(false)
-  const [hideToggle, setHideToggle] = useState(false)
   return (
     <BrowserRouter>
       <LanguageProvider>
@@ -25,13 +24,13 @@ export default function App() {
         <Boar />
         <div className="flex min-h-screen">
           {/** Side navigation with slide toggle **/}
-          <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} hideToggle={hideToggle} />
+          <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} />
           <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-64' : 'ml-0'}`}>
             <Routes>
               <Route path="/" element={<Navigate to="/en" replace />} />
               <Route path="/print" element={<PrintPage />} />
               <Route path="/:lang" element={<WelcomePage />} />
-              <Route path="/:lang/alphabet" element={<AlphabetPage onModalToggle={setHideToggle} />} />
+              <Route path="/:lang/alphabet" element={<AlphabetPage />} />
               <Route path="/:lang/words" element={<WordsPage />} />
               <Route path="/:lang/phrases" element={<PhrasesPage />} />
               <Route path="/:lang/drivers" element={<ReliableDriversPage />} />

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -5,10 +5,9 @@ import AuthPanel from "../components/AuthPanel";
 interface SideNavProps {
   open: boolean
   toggle: () => void
-  hideToggle?: boolean
 }
 
-export default function SideNav({ open, toggle, hideToggle }: SideNavProps) {
+export default function SideNav({ open, toggle }: SideNavProps) {
   const { lang, setLang, t } = useLanguage()
   const location = useLocation()
 
@@ -76,16 +75,14 @@ export default function SideNav({ open, toggle, hideToggle }: SideNavProps) {
         </Link>
         <AuthPanel />
       </nav>
-      {!hideToggle && (
-        <button
-          onClick={toggle}
-          className={`fixed top-12 z-40 bg-sky-200 text-blue-900 border-blue-900 p-1 rounded-r transition-all ${
-            open ? 'left-64 -translate-x-full' : 'left-0'
-          }`}
-        >
-          {open ? '◀' : '▶'}
-        </button>
-      )}
+      <button
+        onClick={toggle}
+        className={`fixed top-12 z-40 bg-sky-200 text-blue-900 border-blue-900 p-1 rounded-r transition-all ${
+          open ? 'left-64 -translate-x-full' : 'left-0'
+        }`}
+      >
+        {open ? '◀' : '▶'}
+      </button>
     </>
   )
 }

--- a/frontend/src/pages/AlphabetPage.tsx
+++ b/frontend/src/pages/AlphabetPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import LetterModal from '../components/LetterModal'
@@ -64,23 +64,9 @@ const letterSoundMap: Record<string, { en: string; ru: string }> = Object.fromEn
   letters.map(([upper, , en, ru]) => [upper, { en, ru }])
 )
 
-interface AlphabetPageProps {
-  onModalToggle?: (hidden: boolean) => void
-}
-
-export default function AlphabetPage({ onModalToggle }: AlphabetPageProps) {
+export default function AlphabetPage() {
   const { t } = useLanguage()
   const [active, setActive] = useState<WordInfo | null>(null)
-
-  useEffect(() => {
-    onModalToggle?.(active !== null)
-  }, [active, onModalToggle])
-
-  useEffect(() => {
-    return () => {
-      onModalToggle?.(false)
-    }
-  }, [onModalToggle])
 
   const openInfo = (letter: string) => {
     const infoList = wordInfoMap[letter]


### PR DESCRIPTION
## Summary
- Remove feature hiding navigation toggle during alphabet popup
- Clean up AlphabetPage and SideNav now that popup no longer dims background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db412b4788321814eb1050b68eeb6