### PR TITLE
Refine mobile side nav layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ export default function App() {
         <div className="flex min-h-screen">
           {/** Side navigation with slide toggle **/}
           <SideNav open={navOpen} toggle={() => setNavOpen(!navOpen)} />
-          <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-64' : 'ml-0'}`}>
+          <div className={`flex-1 transition-all duration-300 ${navOpen ? 'ml-[30vw] sm:ml-64' : 'ml-0'}`}>
             <Routes>
               <Route path="/" element={<Navigate to="/en" replace />} />
               <Route path="/print" element={<PrintPage />} />

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -26,11 +26,19 @@ export default function SideNav({ open, toggle }: SideNavProps) {
   return (
     <>
       <nav
-        className={`fixed top-0 left-0 w-56 sm:w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between
+        className={`fixed top-0 left-0 w-[30vw] sm:w-64 min-h-screen bg-sky-200 text-blue-900 p-6 flex flex-col justify-between
         transform transition-transform duration-300 text-xs sm:text-sm md:text-base ${
           open ? 'translate-x-0' : '-translate-x-full'
-        }`}
+        } relative`}
       >
+        <button
+          onClick={toggle}
+          className={`absolute top-12 right-0 bg-sky-200 text-blue-900 border border-blue-900 p-1 rounded-r z-40 transition-all ${
+            open ? '' : 'translate-x-full'
+          }`}
+        >
+          {open ? '◀' : '▶'}
+        </button>
         <div>
           <Link to={base} className="block uppercase font-bold mb-4">
             {t('welcome_title')}
@@ -75,14 +83,6 @@ export default function SideNav({ open, toggle }: SideNavProps) {
         </Link>
         <AuthPanel />
       </nav>
-      <button
-        onClick={toggle}
-        className={`fixed top-12 z-40 bg-sky-200 text-blue-900 border-blue-900 p-1 rounded-r transition-all ${
-          open ? 'left-56 sm:left-64 -translate-x-full' : 'left-0'
-        }`}
-      >
-        {open ? '◀' : '▶'}
-      </button>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- limit SideNav to 30% viewport width on mobile and move toggle button onto panel
- match content margin with nav width to avoid extra gap

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc22c8d0c83219ac73d7e533ef4ab