### PR TITLE
fix: ensure localized meta tags in prerendered pages

### DIFF
--- a/frontend/src/PrerenderReady.tsx
+++ b/frontend/src/PrerenderReady.tsx
@@ -8,7 +8,11 @@ export default function PrerenderReady() {
   useEffect(() => {
     const seg = pathname.match(/^\/(en|ru)/)?.[1]
     if (import.meta.env.PROD && seg === lang) {
-      document.dispatchEvent(new Event('prerender-ready'))
+      // Defer the event to the next frame so Helmet has time to
+      // inject all meta tags before the prerenderer snapshots.
+      requestAnimationFrame(() => {
+        document.dispatchEvent(new Event('prerender-ready'))
+      })
     }
   }, [lang, pathname])
   return null

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,8 +21,10 @@ export default defineConfig(({ command }) => {
   const prerenderPlugins = prerender({
     routes,
     renderer: new PuppeteerRenderer({
-      // renderAfterDocumentEvent: 'prerender-ready',
-      renderAfterElementExists: 'head link[rel="canonical"]',
+      // Wait until the app signals that prerender data (like meta tags)
+      // has been injected. This avoids capturing empty tags.
+      renderAfterDocumentEvent: 'prerender-ready',
+      // renderAfterElementExists: 'head link[rel="canonical"]',
       skipThirdPartyRequests: true,
       maxConcurrentRoutes: 3,
       // headless: true, // optional; defaults to true


### PR DESCRIPTION
## Summary
- wait for `prerender-ready` event when prerendering so meta tags are populated
- defer `prerender-ready` dispatch until after meta tags mount

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `grep -o '<meta[^>]*>' frontend/dist/en/index.html`
- `grep -o '<meta[^>]*>' frontend/dist/ru/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689f2938704c832192bf8c8a5031eb1f