### PR TITLE
Enable direct links to individual posts

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -36,4 +36,16 @@
   <url>
     <loc>https://am-lang.web.app/ru/interesting_notes</loc>
   </url>
+  <url>
+    <loc>https://am-lang.web.app/en/bilingual_signs</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/bilingual_signs</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/en/small_etudes</loc>
+  </url>
+  <url>
+    <loc>https://am-lang.web.app/ru/small_etudes</loc>
+  </url>
 </urlset>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,9 +35,9 @@ export default function App() {
               <Route path="/:lang/words" element={<WordsPage />} />
               <Route path="/:lang/phrases" element={<PhrasesPage />} />
               <Route path="/:lang/drivers" element={<ReliableDriversPage />} />
-              <Route path="/:lang/interesting_notes" element={<InterestingNotes />} />
-              <Route path="/:lang/bilingual_signs" element={<BilingualSigns />} />
-              <Route path="/:lang/small_etudes" element={<SmallEtudes />} />
+              <Route path="/:lang/interesting_notes/:slug?" element={<InterestingNotes />} />
+              <Route path="/:lang/bilingual_signs/:slug?" element={<BilingualSigns />} />
+              <Route path="/:lang/small_etudes/:slug?" element={<SmallEtudes />} />
               <Route path="*" element={<Navigate to="/en" replace />} />
             </Routes>
           </div>

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -55,7 +55,8 @@ export default function SideNav({ open, toggle }: SideNavProps) {
           </select>
           <ul className="space-y-2">
             {items.map(({ to, label }) => {
-              const active = location.pathname === to
+              const active =
+                location.pathname === to || location.pathname.startsWith(to + '/')
               return (
                 <li key={to}>
                   <Link

--- a/frontend/src/pages/BilingualSigns.tsx
+++ b/frontend/src/pages/BilingualSigns.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { useLanguage, type Lang } from '../useLanguage'
 import Meta from '../components/Meta'
 import hrazdanImg from '../assets/bilingual/hrazdan.webp'
 import type { ReactNode } from 'react'
 
 interface Sign {
+  slug: string
   dateKey: string
   titleKey: string
   render: (t: (key: string) => string, lang: Lang) => ReactNode
@@ -11,6 +14,7 @@ interface Sign {
 
 const signs: Sign[] = [
   {
+    slug: 'hrazdan-railroad-station',
     dateKey: 'sign_2025_07_20_date',
     titleKey: 'sign_2025_07_20_title',
     render: (t, lang) => {
@@ -56,6 +60,14 @@ const signs: Sign[] = [
 
 export default function BilingualSigns() {
   const { t, lang } = useLanguage()
+  const { slug } = useParams<{ slug?: string }>()
+
+  useEffect(() => {
+    if (slug) {
+      document.getElementById(slug)?.scrollIntoView()
+    }
+  }, [slug])
+
   return (
     <>
       <Meta />
@@ -64,8 +76,14 @@ export default function BilingualSigns() {
         <p className="mb-6">{t('bilingual_signs_intro')}</p>
         <ul className="space-y-8">
           {signs.map((sign) => (
-            <li key={sign.titleKey} className="space-y-2">
-              <h2 className="text-lg font-semibold">
+            <li key={sign.slug} id={sign.slug} className="space-y-2">
+              <h2 className="text-lg font-semibold flex items-center">
+                <a
+                  href={`/${lang}/bilingual_signs/${sign.slug}`}
+                  className="mr-2 text-gray-400"
+                >
+                  #
+                </a>
                 {t(sign.dateKey)} - {t(sign.titleKey)}
               </h2>
               <div>{sign.render(t, lang)}</div>

--- a/frontend/src/pages/InterestingNotes.tsx
+++ b/frontend/src/pages/InterestingNotes.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import architectImg from '../assets/architect.webp'
@@ -7,6 +9,7 @@ import hrazdanImg from '../assets/bilingual/hrazdan.webp'
 import type { ReactNode } from 'react'
 
 interface Note {
+  slug: string
   dateKey: string
   titleKey: string
   render: (t: (key: string) => string) => ReactNode
@@ -14,6 +17,7 @@ interface Note {
 
 const notes: Note[] = [
   {
+    slug: 'why-javascript-on-a-language-site',
     dateKey: 'note_2025_07_20_date',
     titleKey: 'note_2025_07_20_title',
     render: (t) => (
@@ -33,6 +37,7 @@ const notes: Note[] = [
     ),
   },
   {
+    slug: 'surprise-in-nork-arabkir-park',
     dateKey: 'note_2025_07_07_date',
     titleKey: 'note_2025_07_07_title',
     render: (t) => (
@@ -52,6 +57,7 @@ const notes: Note[] = [
     ),
   },
   {
+    slug: 'the-pharmacy-owl',
     dateKey: 'note_2025_06_19_date',
     titleKey: 'note_2025_06_19_title',
     render: (t) => (
@@ -70,6 +76,7 @@ const notes: Note[] = [
     ),
   },
   {
+    slug: 'its-impossible-to-pronounce',
     dateKey: 'note_2025_06_17_date',
     titleKey: 'note_2025_06_17_title',
     render: (t) => (
@@ -90,26 +97,40 @@ const notes: Note[] = [
 ]
 
 export default function InterestingNotes() {
-  const { t } = useLanguage()
+  const { t, lang } = useLanguage()
+  const { slug } = useParams<{ slug?: string }>()
+
+  useEffect(() => {
+    if (slug) {
+      document.getElementById(slug)?.scrollIntoView()
+    }
+  }, [slug])
+
   return (
     <>
       <Meta />
       <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">
-        {t('interesting_notes_title')}
-      </h1>
-      <p className="mb-6">{t('interesting_notes_intro')}</p>
-      <ul className="space-y-8">
-        {notes.map((note) => (
-          <li key={note.titleKey} className="space-y-2">
-            <h2 className="text-lg font-semibold">
-              {t(note.dateKey)} - {t(note.titleKey)}
-            </h2>
-            <div>{note.render(t)}</div>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <h1 className="text-xl font-bold mb-4">
+          {t('interesting_notes_title')}
+        </h1>
+        <p className="mb-6">{t('interesting_notes_intro')}</p>
+        <ul className="space-y-8">
+          {notes.map((note) => (
+            <li key={note.slug} id={note.slug} className="space-y-2">
+              <h2 className="text-lg font-semibold flex items-center">
+                <a
+                  href={`/${lang}/interesting_notes/${note.slug}`}
+                  className="mr-2 text-gray-400"
+                >
+                  #
+                </a>
+                {t(note.dateKey)} - {t(note.titleKey)}
+              </h2>
+              <div>{note.render(t)}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
     </>
   )
 }

--- a/frontend/src/pages/SmallEtudes.tsx
+++ b/frontend/src/pages/SmallEtudes.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import primitiveImg from '../assets/etudes/primitive_reference.webp'
@@ -12,6 +14,7 @@ interface Etude {
   shortTextKeys: string[]
   img: string
   code?: string
+  slug: string
 }
 
 const etudes: Etude[] = [
@@ -27,6 +30,7 @@ const etudes: Etude[] = [
       'etude_2025_08_17_short4',
     ],
     img: hoistingImg,
+    slug: 'hoisting',
   },
   {
     titleKey: 'etude_2025_08_15_title',
@@ -42,6 +46,7 @@ const etudes: Etude[] = [
       'etude_2025_08_15_short6',
     ],
     img: letVarConstImg,
+    slug: 'let-var-const',
   },
   {
     titleKey: 'etude_2025_07_08_title',
@@ -69,11 +74,19 @@ let b = a;
 b[0] = 8;
 console.log(a, b)
 // [8], [8]`,
+    slug: 'types-primitive-object',
   },
 ]
 
 export default function SmallEtudes() {
-  const { t } = useLanguage()
+  const { t, lang } = useLanguage()
+  const { slug } = useParams<{ slug?: string }>()
+
+  useEffect(() => {
+    if (slug) {
+      document.getElementById(slug)?.scrollIntoView()
+    }
+  }, [slug])
   return (
     <>
       <Meta />
@@ -82,8 +95,14 @@ export default function SmallEtudes() {
         <p className="mb-6">{t('small_etudes_intro')}</p>
         <ul className="space-y-8">
           {etudes.map((etude) => (
-            <li key={etude.dateKey}>
-              <h2 className="text-lg font-semibold mb-2">
+            <li key={etude.slug} id={etude.slug}>
+              <h2 className="text-lg font-semibold mb-2 flex items-center">
+                <a
+                  href={`/${lang}/small_etudes/${etude.slug}`}
+                  className="mr-2 text-gray-400"
+                >
+                  #
+                </a>
                 {t(etude.titleKey)}
               </h2>
               <div className="grid md:grid-cols-3 gap-4 items-start">


### PR DESCRIPTION
## Summary
- Add slugs and anchor links to small etudes, interesting notes and bilingual signs
- Support optional slug routes that scroll to the referenced article
- Update navigation and route config, but only prerender top-level pages to avoid useless per-post builds

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5259800832188cae8ef513ba542