### PR TITLE
Gate alphabet and word trainers by auth

### DIFF
--- a/frontend/src/pages/WordsPage.tsx
+++ b/frontend/src/pages/WordsPage.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
 import { useLanguage } from '../useLanguage'
 import Meta from '../components/Meta'
 import { rawWordInfoList } from '../data/rawWordInfoList'
 import WordCard, { type Word } from '../components/WordCard'
+import { auth } from '../lib/firebase'
 
 export const selectedWordEns = new Set([
   'apple',
@@ -60,19 +63,40 @@ const words: Word[] = rawWordInfoList
     soundEn: w.soundEn ?? [],
     en: w.wordEn!,
     ru: w.wordRu!,
-  }))
+}))
+
+const defaultLetters = new Set(['Ա', 'Բ', 'Գ', 'Խ', 'Շ', 'Ֆ', 'Մ'])
 
 export default function WordsPage() {
   const { t } = useLanguage()
+  const [authorized, setAuthorized] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setAuthorized(u != null)
+    })
+    return () => unsub()
+  }, [])
   return (
     <>
       <Meta />
       <div className="p-4">
         <h1 className="text-xl font-bold mb-4">{t('words_title')}</h1>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {words.map((w) => (
-            <WordCard key={w.wordLower.join('')} word={w} />
-          ))}
+          {words.map((w) => {
+            const initial = w.wordUpper[0]
+            const isAccessible = authorized || defaultLetters.has(initial)
+            return isAccessible ? (
+              <WordCard key={w.wordLower.join('')} word={w} />
+            ) : (
+              <div
+                key={w.wordLower.join('')}
+                className="flex justify-center items-center"
+              >
+                <div className="w-24 sm:w-32 md:w-40 h-40 bg-gray-200 rounded" />
+              </div>
+            )
+          })}
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- Limit alphabet trainer access to select letters for unauthenticated users and highlight locked letters in brick orange
- Show placeholder blocks for locked words in words trainer
- Authenticate alphabet and word trainers using Firebase auth state

## Testing
- `npm run lint`
- `npm run build` (fails: libatk-1.0.so.0 missing)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9936771808321bdbcd52a694b7c38