### PR TITLE
Fix auth inputs exceeding container width

### DIFF
--- a/frontend/src/App_test_login.tsx
+++ b/frontend/src/App_test_login.tsx
@@ -70,18 +70,22 @@ export default function App() {
     <div style={{ maxWidth: 420, margin: "40px auto", fontFamily: "system-ui" }}>
       <h1>{isNew ? "Create account" : "Sign in"}</h1>
       <form onSubmit={handleSubmit}>
-        <div style={{ display: "grid", gap: 8 }}>
+        <div style={{ display: "grid", gap: 8, width: "100%" }}>
           <input
             type="email"
             placeholder="Email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)} required
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            style={{ width: "100%" }}
           />
           <input
             type="password"
             placeholder="Password"
             value={pass}
-            onChange={(e) => setPass(e.target.value)} required
+            onChange={(e) => setPass(e.target.value)}
+            required
+            style={{ width: "100%" }}
           />
           <button type="submit">{isNew ? "Register" : "Sign in"}</button>
         </div>

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -39,22 +39,42 @@ export default function AuthPanel() {
 
   if (user) {
     return (
-      <div style={{ padding: "1rem", border: "1px solid #ccc", borderRadius: 4 }}>
-        <p>Signed in as <b>{user.email}</b></p>
+      <div
+        style={{
+          padding: "1rem",
+          border: "1px solid #ccc",
+          borderRadius: 4,
+          width: "100%",
+        }}
+      >
+        <p>
+          Signed in as <b>{user.email}</b>
+        </p>
         <button onClick={() => signOut(auth)}>Sign out</button>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: "1rem", border: "1px solid #ccc", borderRadius: 4 }}>
-      <form onSubmit={handleSubmit} style={{ display: "grid", gap: 8 }}>
+    <div
+      style={{
+        padding: "1rem",
+        border: "1px solid #ccc",
+        borderRadius: 4,
+        width: "100%",
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: "grid", gap: 8, width: "100%" }}
+      >
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
+          style={{ width: "100%" }}
         />
         <input
           type="password"
@@ -62,6 +82,7 @@ export default function AuthPanel() {
           value={pass}
           onChange={(e) => setPass(e.target.value)}
           required
+          style={{ width: "100%" }}
         />
         <button type="submit">{isNew ? "Register" : "Sign in"}</button>
       </form>


### PR DESCRIPTION
## Summary
- ensure AuthPanel inputs and container span full width to avoid overflow
- align test login component with same full-width inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a99f965a6c8321a19e03d9d4ff2cde